### PR TITLE
Remove typehint for $message in flashMessage

### DIFF
--- a/src/Application/UI/Control.php
+++ b/src/Application/UI/Control.php
@@ -69,7 +69,7 @@ abstract class Control extends Component implements IRenderable
 	/**
 	 * Saves the message to template, that can be displayed after redirect.
 	 */
-	public function flashMessage(string $message, string $type = 'info'): \stdClass
+	public function flashMessage($message, string $type = 'info'): \stdClass
 	{
 		$id = $this->getParameterId('flash');
 		$messages = $this->getPresenter()->getFlashSession()->$id;


### PR DESCRIPTION
I'm removing typehint for display Nette\Utils\Html in $message

- bug fix? no
- new feature? no
- BC break? no
- doc PR: no

<!--
I'm removing typehint for display Nette\Utils\Html in $message
-->
